### PR TITLE
Make JavaDoc `@param` and `@return` tags optional

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -101,7 +101,10 @@
     <!-- See https://checkstyle.org/config_javadoc.html -->
     <!-- <module name="JavadocVariable"/> -->
     <module name="InvalidJavadocPosition"/>
-    <module name="JavadocMethod"/>
+    <module name="JavadocMethod">
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+    </module>
     <module name="JavadocType"/>
     <module name="JavadocStyle"/>
     <module name="MissingJavadocMethod">


### PR DESCRIPTION
Applicata seconda patch 'fix-checkstyle.config-2.patch" sul file di configurazione di CheckStyle

Closes #18 